### PR TITLE
fix: Replace getBedLocation() with getRespawnLocation() in updateCompass for Folia 26.1.2

### DIFF
--- a/patches/plugins/0021-Fix-EssentialsPlayerListener-updateCompass.patch
+++ b/patches/plugins/0021-Fix-EssentialsPlayerListener-updateCompass.patch
@@ -3,27 +3,28 @@ From: Euphyllia Bierque <bierque.euphyllia@gmail.com>
 Date: Tue, 19 May 2026 12:27:03 +0200
 Subject: [PATCH 21/21] Fix EssentialsPlayerListener#updateCompass
 
+Fix IllegalStateException("Not sleeping") thrown by CraftPlayer.getBedLocation()
+on Folia 26.1.2. Replace getBedLocation() with getRespawnLocation() which does
+not require the player to be sleeping and returns the player's respawn point.
+
 ---
- .../earth2me/essentials/EssentialsPlayerListener.java | 11 +++++++++++
- 1 file changed, 11 insertions(+)
+ .../earth2me/essentials/EssentialsPlayerListener.java | 8 ++++++++
+ 1 file changed, 8 insertions(+)
 
 diff --git a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
-index a90a56c47..9ee14b52e 100644
+index a90a56c47..b1c2e3f01 100644
 --- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
 +++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
-@@ -622,6 +622,17 @@ public class EssentialsPlayerListener implements Listener {
+@@ -622,6 +622,14 @@ public class EssentialsPlayerListener implements Listener {
  
          final Location loc = user.getHome(user.getLocation());
          if (loc == null) {
 +            if (VersionUtil.isFoliaServer()) {
 +                final Player player = user.getBase();
-+                final Location bedLocation = player.getBedLocation();
-+                if (bedLocation == null) return;
-+                player.teleportAsync(bedLocation, TeleportCause.PLUGIN).thenAccept(success -> {
-+                    if (success) {
-+                        user.getBase().setCompassTarget(bedLocation);
-+                    }
-+                });
++                final Location respawnLocation = player.getRespawnLocation();
++                if (respawnLocation != null) {
++                    player.setCompassTarget(respawnLocation);
++                }
 +                return;
 +            }
              PaperLib.getBedSpawnLocationAsync(user.getBase(), false).thenAccept(location -> {
@@ -31,4 +32,3 @@ index a90a56c47..9ee14b52e 100644
                      user.getBase().setCompassTarget(location);
 -- 
 2.54.0.windows.1
-


### PR DESCRIPTION
## Problem

On Folia 26.1.2, `CraftPlayer.getBedLocation()` now throws `IllegalStateException("Not sleeping")` when called on a player who is not currently in a bed. This causes a crash during player join:

```
java.lang.IllegalStateException: Not sleeping
        at com.google.common.base.Preconditions.checkState(Preconditions.java:513)
        at org.bukkit.craftbukkit.entity.CraftPlayer.getBedLocation(CraftPlayer.java:1454)
        at com.earth2me.essentials.EssentialsPlayerListener.updateCompass(EssentialsPlayerListener.java:627)
        at com.earth2me.essentials.EssentialsPlayerListener.joinFlow(EssentialsPlayerListener.java:433)
```

## Fix

Replace `player.getBedLocation()` with `player.getRespawnLocation()` in the Folia-specific branch of `updateCompass()`.

`getRespawnLocation()` returns the player's respawn point (bed or respawn anchor) without requiring the player to be currently sleeping, and safely returns `null` if no respawn point has been set.

Additionally, removed the unnecessary `teleportAsync()` call that was in the original patch — the `updateCompass` method should only set the compass target, not teleport the player.

## Changes

- `patches/plugins/0021-Fix-EssentialsPlayerListener-updateCompass.patch`: Updated to use `getRespawnLocation()` instead of `getBedLocation()`, and simplified the logic to just set the compass target without teleporting.